### PR TITLE
Fix set data bug

### DIFF
--- a/Scripts/global.js
+++ b/Scripts/global.js
@@ -791,7 +791,7 @@ function commandPack(sender, rawargs) {
       function addCardsToPacks() {
         // find entry for us in booster database
         const fullSetData = allBoosters[packData.code];
-        const booster = fullSetData.booster.default;
+        const booster = fullSetData.booster.default || fullSetData.booster.draft;
         for (let i = 0; i < qty; i++) {
           // generate a new pack
           console.log("Making pack " + i);


### PR DESCRIPTION
When I run `/pack CLB`, the following error occurs in the chat:

```
An internal error occured!
```

The following error occurs in devtools:

```
fetching booster info for CLB
 booster info for CLB fetched
 Making pack 0
 Exception in /pack: TypeError: Cannot read properties of undefined (reading 'boostersTotalWeight')
```

Some of the `Set` data retrieved from MTGJSON does not include a value for `booster.default.boostersTotalWeight`, only `booster.draft.boostersTotalWeight`. I added the `draft` key as a fallback, so it works to create packs now. 

This was only tested with the CLB set. My assumption is that the data is just slightly different for draft sets. 